### PR TITLE
Add minimum perl version to Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ my %conf = (
 	'NAME'         => 'Text::MediawikiFormat',
 	'VERSION_FROM' => 'lib/Text/MediawikiFormat.pm',
 	'PREREQ_PM'    => {
+		'perl'             => '5.006',
 		'CGI'              => '0',
 		'Scalar::Util'     => '1.14',
 		'Test::More'       => '0.3',


### PR DESCRIPTION
Which will then show up in META.{yml,json}
This is to address kwalitee issue meta_yml_declares_perl_version
https://cpants.cpanauthors.org/dist/Text-MediawikiFormat

Version (5.006) has been found with Perl::MinimumVersion.